### PR TITLE
Run CI on specific PHP version (7.4)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,19 +5,73 @@ on: push
 jobs:
   kahlan:
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        php-versions: ['7.4']
     steps:
       - uses: actions/checkout@v2
-      - run: composer install --no-interaction
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+      - name: Install dependencies
+        run: composer install --no-interaction
       - run: vendor/bin/kahlan
   psalm:
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        php-versions: ['7.4']
     steps:
       - uses: actions/checkout@v2
-      - run: composer install --no-interaction
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+      - name: Install dependencies
+        run: composer install --no-interaction
       - run: vendor/bin/psalm
   php-cs-fixer:
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        php-versions: ['7.4']
     steps:
       - uses: actions/checkout@v2
-      - run: composer install --no-interaction
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+      - name: Install dependencies
+        run: composer install --no-interaction
       - run: vendor/bin/php-cs-fixer fix --dry-run -v --diff


### PR DESCRIPTION
Before: we were just running CI on whatever PHP versions Ubuntu 20.04
provides by default

Now: we're specifically running it on PHP 7.4