### PR TITLE
Fix workflow syntax

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
   kahlan:
     runs-on: ubuntu-24.04
     strategy:
-      matrix
+      matrix:
         php-versions: ['8.2']
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
I'm not sure how this didn't trigger a failure in [the PR](https://github.com/dxw/wordpress-plugin-template/pull/9), but it did once it was merged.